### PR TITLE
get_thumbnail_name: use os.path.sep as directory separator

### DIFF
--- a/pelican/plugins/thumbnailer/test_thumbnails.py
+++ b/pelican/plugins/thumbnailer/test_thumbnails.py
@@ -2,7 +2,6 @@ import os
 from unittest import TestCase, main
 
 from PIL import Image
-
 from thumbnailer import Resizer
 
 

--- a/pelican/plugins/thumbnailer/thumbnailer.py
+++ b/pelican/plugins/thumbnailer/thumbnailer.py
@@ -94,7 +94,7 @@ class Resizer(object):
         # Find the partial path + filename beyond the input image directory.
         prefix = path.commonprefix([in_path, self._root])
         new_filename = in_path[len(prefix) :]
-        if new_filename.startswith("/"):
+        if new_filename.startswith(os.path.sep):
             new_filename = new_filename[1:]
 
         # Generate the new filename.


### PR DESCRIPTION
The old mechanism leads to thumbs being generated in the root directory on Windows platforms.