### PR TITLE
Change of Image.ANTIALIAS to Image.LANCZOS (Pillow >=10.1 compatibility)

### DIFF
--- a/pelican/plugins/thumbnailer/test_thumbnails.py
+++ b/pelican/plugins/thumbnailer/test_thumbnails.py
@@ -2,7 +2,6 @@ import os
 from unittest import TestCase, main
 
 from PIL import Image
-
 from thumbnailer import Resizer
 
 

--- a/pelican/plugins/thumbnailer/thumbnailer.py
+++ b/pelican/plugins/thumbnailer/thumbnailer.py
@@ -46,7 +46,7 @@ class Resizer(object):
 
     def _aspect_resize(self, w, h, image):
         retval = image.copy()
-        retval.thumbnail((w, h), Image.ANTIALIAS)
+        retval.thumbnail((w, h), Image.LANCZOS)
 
         return retval
 


### PR DESCRIPTION
Changed Image.ANTIALIAS to Image.LANCZOS to provide Pillow >=10.1 compatibility in accordance to https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias